### PR TITLE
Replaces OAC footer

### DIFF
--- a/.githooks/lib-pre-commit/footers
+++ b/.githooks/lib-pre-commit/footers
@@ -12,7 +12,7 @@ status() {
     fi
 }
 
-echo "Running pre-commit hook: Managing OAC footer in markdown files..."
+echo "Running pre-commit hook: Managing RAMATE footer in markdown files..."
 
 # Find all tracked markdown files in the repository, excluding template files
 FILES=$(git ls-files --cached --exclude-standard -- '*.md' | grep -v '\.template\.md$')
@@ -39,7 +39,7 @@ for file in $FILES; do
     # Remove existing footer if present and clean up whitespace
     awk '
         BEGIN { in_footer=0; last_was_empty=0 }
-        /<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->/ { in_footer=1; next }
+        /<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->/ { in_footer=1; next }
         in_footer && /^--$/ { next }
         in_footer && /^<h5>/ { next }
         in_footer && /^<\/h5>/ { in_footer=0; next }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To produce and maintain these [Artifacts](./rglo/rera-000-000-000-dulan/rglo-000
 | [Release Candidates](https://github.com/ramate-io/oac/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease-candidate) | Feature-complete versions linked to events. |
 | [Features & Bugs](https://github.com/ramate-io/oac/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature%2Cbug%20label%3Apriority%3Aurgent%2Cpriority%3Ahigh) | High-priority `feature` and `bug` issues. |
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Under [RGLO-0](./rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md
 - [`rpre`](./rpre/): Ramate Presentations (RPRE) are presentations about Ramate.
 - [`rdemo`](./rdemo/): Ramate Demonstrations (RDEMO) are selected demonstrations of Ramate technologies.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/assets/footer.template.md
+++ b/assets/footer.template.md
@@ -1,4 +1,4 @@
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ We have documented the following features:
 
 - **[GitHub Workflows](./github-workflows/)**
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/docs/github-workflows/README.md
+++ b/docs/github-workflows/README.md
@@ -6,7 +6,7 @@ There are two categories of workflows presented as subdirectories:
 - **[Validation](./validation/)**: workflows concerned with validating the correctness of changes.
 - **[Delivery](./delivery/)**: workflows concerned with delivering changes.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/docs/github-workflows/delivery/README.md
+++ b/docs/github-workflows/delivery/README.md
@@ -1,7 +1,7 @@
 # Delivery
 Delivery workflows are concerned with delivering changes.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/docs/github-workflows/validation/README.md
+++ b/docs/github-workflows/validation/README.md
@@ -4,7 +4,7 @@ Validation workflows are concerned with validating the correctness of changes.
 ## [Labels](./labels/)
 The **Labels** workflows are concerned with maintaining GitHub labels.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/docs/github-workflows/validation/labels/README.md
+++ b/docs/github-workflows/validation/labels/README.md
@@ -11,7 +11,7 @@ The labels worfklow will delete additional labels when run on `main` or when the
 > [!WARN]
 > There are NOT currently any protections against this updating of labels. As a contributor, you should be mindful particularly not to remove labels without first checking with other contributors.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rart/README.md
+++ b/rart/README.md
@@ -5,7 +5,7 @@ Description of RART.
 ## [RART: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RART-0](/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/README.md):** describes the relevance of Lamport et al., 1972, The Byzantine General Problem.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rart/rera-000-000-000-dulan/README.md
+++ b/rart/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RARTs
 - **[RART-0](/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/README.md):** describes the relevance of Lamport et al., 1972, The Byzantine General Problem.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/README.md
+++ b/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/README.md
@@ -40,7 +40,7 @@ $\emptyset$
 
 ## Dissenting
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/agreeing/con-001-liam-monninger/README.md
+++ b/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/dissenting/dis-001-liam-monninger/README.md
+++ b/rart/rera-000-000-000-dulan/rart-000-000-000-byzantine-generals/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rcert/README.md
+++ b/rcert/README.md
@@ -5,7 +5,7 @@ Description of RCERT.
 ## [RCERT: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 **[RCERT-0: OAC](/rcert/rera-000-000-000-dulan/rcert-000-000-000-oac/README.md):** self-certifies this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rcert/rera-000-000-000-dulan/README.md
+++ b/rcert/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RCERTs
 **[RCERT-0: OAC](/rcert/rera-000-000-000-dulan/rcert-000-000-000-oac/README.md):** self-certifies this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/README.md
+++ b/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/README.md
@@ -43,7 +43,7 @@ We stipulate that the validity of this certificate depends upon its continued pr
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/agreeing/con-001-liam-monninger/README.md
+++ b/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/dissenting/dis-001-liam-monninger/README.md
+++ b/rcert/rera-000-000-000-dulan/rcert-000-000-000-ramate/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rde/README.md
+++ b/rde/README.md
@@ -5,7 +5,7 @@ Description of RDE.
 ## [RDE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RDE-0](/rde/rera-000-000-000-dulan/rde-000-000-000/README.md):** requests standards for maintenance of this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rde/rera-000-000-000-dulan/README.md
+++ b/rde/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RDEs
 - **[RDE-0](/rde/rera-000-000-000-dulan/rde-000-000-000/README.md):** requests standards for maintenance of this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rde/rera-000-000-000-dulan/rde-000-000-000/README.md
+++ b/rde/rera-000-000-000-dulan/rde-000-000-000/README.md
@@ -34,7 +34,7 @@ In addition to drafting individual [Artifacts](../../../rglo/rera-000-000-000-du
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rde/rera-000-000-000-dulan/rde-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rde/rera-000-000-000-dulan/rde-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rde/rera-000-000-000-dulan/rde-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rde/rera-000-000-000-dulan/rde-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rdemo/README.md
+++ b/rdemo/README.md
@@ -4,7 +4,7 @@ Description of RDEMO.
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RDEMO: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rdemo/rera-000-000-000-dulan/README.md
+++ b/rdemo/rera-000-000-000-dulan/README.md
@@ -2,7 +2,7 @@
 
 ## RDEMOs
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rdemo/rera-000-000-000-dulan/rdemo-000-000-000/README.md
+++ b/rdemo/rera-000-000-000-dulan/rdemo-000-000-000/README.md
@@ -46,7 +46,7 @@ OAC de-emphasizes perfect consensus. The primary motive of OAC is to track state
 ### What would be built with OAC?
 When used carefully, we believe OAC can supplant traditional and popular decentralized and distributed compute under requirements such as smart execution and state machine replication. However, OAC's long-term ambitions lie in machine-to-machine communication. We believe OAC can be used to help solve challenging problems in AI alignment, dPIN verification, and decentralized swarm coordination.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rera/README.md
+++ b/rera/README.md
@@ -5,7 +5,7 @@ The current era is [RERA-0: Dulan](./rera-000-000-000-dulan/README.md).
 
 - **[RERA-0: Dulan](./rera-000-000-000-dulan/README.md):** the foundational era in which OAC is bootstrapped by [Ramate LLC](https://www.ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rera/rera-000-000-000-dulan/README.md
+++ b/rera/rera-000-000-000-dulan/README.md
@@ -75,7 +75,7 @@ As described in [RGOV-0](../../rgov/rera-000-000-000-dulan/rgov-000-000-000/READ
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rera/rera-000-000-000-dulan/agreeing/con-001-liam-monninger/README.md
+++ b/rera/rera-000-000-000-dulan/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rera/rera-000-000-000-dulan/dissenting/dis-001-liam-monninger/README.md
+++ b/rera/rera-000-000-000-dulan/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rglo/README.md
+++ b/rglo/README.md
@@ -5,7 +5,7 @@ Description of RGLO
 ## [RGLO: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RGLO-0: Artifact](/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md):** defines the term Artifact which refers to the various O* documents.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rglo/rera-000-000-000-dulan/README.md
+++ b/rglo/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RGLOs
 - **[RGLO-0: Artifact](/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md):** defines the term Artifact which refers to the various O* documents.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md
+++ b/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md
@@ -22,7 +22,7 @@ All other artifacts are either "Proposed" or "Revoked" and their status is refle
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/agreeing/con-001-liam-monninger/README.md
+++ b/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/dissenting/dis-001-liam-monninger/README.md
+++ b/rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rgov/README.md
+++ b/rgov/README.md
@@ -5,7 +5,7 @@ Description of RGOV
 ## [RGOV: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 **[RGOV-0](/rgov/rera-000-000-000-dulan/rgov-000-000-000/README.md):** describes the initial governance under [Ramate LLC](https://www.ramate.io).
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rgov/rera-000-000-000-dulan/README.md
+++ b/rgov/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RGOVs
 **[RGOV-0](/rgov/rera-000-000-000-dulan/rgov-000-000-000/README.md):** describes the initial governance under [Ramate LLC](https://www.ramate.io).
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rgov/rera-000-000-000-dulan/rgov-000-000-000/README.md
+++ b/rgov/rera-000-000-000-dulan/rgov-000-000-000/README.md
@@ -44,7 +44,7 @@ We assert there is no precedence for interpretation owing to the lack of [contin
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rgov/rera-000-000-000-dulan/rgov-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rgov/rera-000-000-000-dulan/rgov-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rgov/rera-000-000-000-dulan/rgov-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rgov/rera-000-000-000-dulan/rgov-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rguide/README.md
+++ b/rguide/README.md
@@ -5,7 +5,7 @@ OAC Guides (RGUIDE) provide useful guides and summaries of OAC.
 ## [RGUIDE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RGUIDE-0](/rguide/rera-000-000-000-dulan/rguide-000-000-000/README.md):** describes the initial drive towards decentralized consequence and the suggested foundational papers.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rguide/rera-000-000-000-dulan/README.md
+++ b/rguide/rera-000-000-000-dulan/README.md
@@ -4,7 +4,7 @@
 ## RGUIDEs
 - **[RGUIDE-0](/rguide/rera-000-000-000-dulan/rguide-000-000-000/README.md):** describes the initial drive towards decentralized consequence and the suggested foundational papers.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rguide/rera-000-000-000-dulan/rguide-000-000-000/README.md
+++ b/rguide/rera-000-000-000-dulan/rguide-000-000-000/README.md
@@ -26,7 +26,7 @@ Once you've done the above, you should have a strong enough sense of the project
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rguide/rera-000-000-000-dulan/rguide-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rguide/rera-000-000-000-dulan/rguide-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rguide/rera-000-000-000-dulan/rguide-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rguide/rera-000-000-000-dulan/rguide-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rleg/README.md
+++ b/rleg/README.md
@@ -5,7 +5,7 @@ Description of RLEG.
 ## [RLEG: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RLEG-0](/rleg/rera-000-000-000-dulan/rleg-000-000-000/README.md):** describes the initial lack of binding legal organization, provides the MIT License as the only relevant material.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rleg/rera-000-000-000-dulan/README.md
+++ b/rleg/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RLEGs
 - **[RLEG-0](/rleg/rera-000-000-000-dulan/rleg-000-000-000/README.md):** describes the initial lack of binding legal organization, provides the MIT License as the only relevant material.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rleg/rera-000-000-000-dulan/rleg-000-000-000/README.md
+++ b/rleg/rera-000-000-000-dulan/rleg-000-000-000/README.md
@@ -28,7 +28,7 @@ OAC is provided under an [MIT License](https://opensource.org/license/mit).
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rlog/README.md
+++ b/rlog/README.md
@@ -4,7 +4,7 @@
 ## [RLOG: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RLOG-0](/rlog/rera-000-000-000-dulan/rlog-000-000-000/README.md):** some playing around with combinatorics from BFA paper for [RPRE-0](/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md) and similar.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rlog/rera-000-000-000-dulan/README.md
+++ b/rlog/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RLOGs
 - **[RLOG-0](/rlog/rera-000-000-000-dulan/rlog-000-000-000/README.md):** some playing around with combinatorics from BFA paper for [RPRE-0](/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md) and similar.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rlog/rera-000-000-000-dulan/rlog-000-000-000/README.md
+++ b/rlog/rera-000-000-000-dulan/rlog-000-000-000/README.md
@@ -107,7 +107,7 @@ c'(n, k) = \sum_{h = 2k + 1}^{\min(3k + 1, 2n + 1)} \binom{n}{h} \cdot \binom{n}
 \end{aligned}
 ```
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rpre/README.md
+++ b/rpre/README.md
@@ -4,7 +4,7 @@
 ## [RPRE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RPRE-0](/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md):** an introduction to OAC for the prrspective contributor.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rpre/rera-000-000-000-dulan/README.md
+++ b/rpre/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RPREs
 - **[RPRE-0](/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md):** an introduction to OAC for the prrspective contributor.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md
+++ b/rpre/rera-000-000-000-dulan/rpre-000-000-000/README.md
@@ -24,7 +24,7 @@ The linked deck and presentation describe Ramate's long-term aspirations, its cu
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rpre/rera-000-000-000-dulan/rpre-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rpre/rera-000-000-000-dulan/rpre-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rpre/rera-000-000-000-dulan/rpre-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rpre/rera-000-000-000-dulan/rpre-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rproc/README.md
+++ b/rproc/README.md
@@ -4,7 +4,7 @@
 ## [RPROC: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RPROC-0](/rproc/rera-000-000-000-dulan/rproc-000-000-000/README.md):** an aspirational statement of initial intent for OAC: building decentralized consequence.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rproc/rera-000-000-000-dulan/README.md
+++ b/rproc/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RPROCs
 - **[RPROC-0](/rproc/rera-000-000-000-dulan/rproc-000-000-000/README.md):** an aspirational statement of initial intent for OAC: building decentralized consequence.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rproc/rera-000-000-000-dulan/rproc-000-000-000/README.md
+++ b/rproc/rera-000-000-000-dulan/rproc-000-000-000/README.md
@@ -52,7 +52,7 @@ OAC de-emphasizes perfect consensus. The primary motive of OAC is to track state
 ### What would be built with OAC?
 When used carefully, we believe OAC can supplant traditional and popular decentralized and distributed compute under requirements such as smart execution and state machine replication. However, OAC's long-term ambitions lie in machine-to-machine communication. We believe OAC can be used to help solve challenging problems in AI alignment, dPIN verification, and decentralized swarm coordination.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rroad/README.md
+++ b/rroad/README.md
@@ -4,7 +4,7 @@
 ## [RROAD: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RROAD-0](/rroad/rera-000-000-000-dulan/rroad-000-000-000/README.md):** the initial roadmap for OAC.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rroad/rera-000-000-000-dulan/README.md
+++ b/rroad/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RROADs
 - **[RROAD-0](/rroad/rera-000-000-000-dulan/rroad-000-000-000/README.md):** the initial roadmap for OAC.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rroad/rera-000-000-000-dulan/rroad-000-000-000/README.md
+++ b/rroad/rera-000-000-000-dulan/rroad-000-000-000/README.md
@@ -340,7 +340,7 @@ In the very least, this update of governance should include moving OAC out from 
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rroad/rera-000-000-000-dulan/rroad-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rroad/rera-000-000-000-dulan/rroad-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rroad/rera-000-000-000-dulan/rroad-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rroad/rera-000-000-000-dulan/rroad-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -4,7 +4,7 @@
 ## [RSPEC: RERA-0: DULAN](rera-000-000-000-dulan/README.md)
 - **[RSPEC-0](/rspec/rera-000-000-000-dulan/rspec-000-000-000/README.md):** a specification for how to use and maintain this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rspec/rera-000-000-000-dulan/README.md
+++ b/rspec/rera-000-000-000-dulan/README.md
@@ -3,7 +3,7 @@
 ## RSPECs
 - **[RSPEC-0](/rspec/rera-000-000-000-dulan/rspec-000-000-000/README.md):** a specification for how to use and maintain this repository.
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rspec/rera-000-000-000-dulan/rspec-000-000-000/README.md
+++ b/rspec/rera-000-000-000-dulan/rspec-000-000-000/README.md
@@ -58,7 +58,7 @@ We assert this is an arbitrary and adaptive standard that contains no obvious co
 ## Appendix
 $\emptyset$
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rspec/rera-000-000-000-dulan/rspec-000-000-000/agreeing/con-001-liam-monninger/README.md
+++ b/rspec/rera-000-000-000-dulan/rspec-000-000-000/agreeing/con-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # AGR-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">

--- a/rspec/rera-000-000-000-dulan/rspec-000-000-000/dissenting/dis-001-liam-monninger/README.md
+++ b/rspec/rera-000-000-000-dulan/rspec-000-000-000/dissenting/dis-001-liam-monninger/README.md
@@ -1,7 +1,7 @@
 # DIS-1: Liam Monninger
 - **Authors:** [Liam Monninger](mailto:liam@ramate.io)
 
-<!--OAC FOOTER: DO NOT REMOVE THIS LINE-->
+<!--RAMATE FOOTER: DO NOT REMOVE THIS LINE-->
 ---
 
 <div align="center">


### PR DESCRIPTION
# Summary
Replaces OAC footer. 

> [!NOTE]
> In this case, all that was needed was the replacement of the `OAC FOOTER` template text and the corresponding update to the pre-commit hook. 