### PR TITLE
Fix bad descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) file for additional contribution g
 
 ### Artifacts
 Under [RGLO-0](./rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md), this subsection defines the recognized artifact types. We recognize the following types:
+
 - [`rera`](./rera): Ramate Eras (RERA) are the periods over which a governing body makes decisions. All other Ramate [Artifacts](./rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md) are indexed by RERA.
 - [`rglo`](./rglo/): Ramate Glosses (RGLO) are defined terms for Ramate.
 - [`rproc`](./rproc/): Ramate Proclamations (RPROC) are statements of purpose for Ramate.

--- a/rart/README.md
+++ b/rart/README.md
@@ -1,5 +1,5 @@
 # RART
-Description of RART.
+Ramate Articles (RART) are academic papers and similar content which are designated as key to Ramate pursuits. In comparison to OAC, these articles are less focused and included as a sort of "mood wall" for contributors and members of the organization.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RART: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rcert/README.md
+++ b/rcert/README.md
@@ -1,5 +1,5 @@
 # RCERT
-Description of RCERT.
+Ramate Certificates (RCERT) certify a given project as abiding by the OAC paradigm.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RCERT: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rde/README.md
+++ b/rde/README.md
@@ -1,5 +1,5 @@
 # RDE
-Description of RDE.
+Ramate Desiderata (RDE) describe wants, open problems, and similar within the Ramate paradigm.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RDE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rdemo/README.md
+++ b/rdemo/README.md
@@ -1,5 +1,5 @@
 # RDEMO
-RDEMOs are demonstrations of Ramate technologies, processes, and similar.
+Ramate Demonstrations (RDEMO) are selected demonstrations of Ramate technologies.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RDEMO: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rera/README.md
+++ b/rera/README.md
@@ -1,5 +1,5 @@
 # RERA
-OAC Eras (RERA) are the periods over which a governing body makes decisions. All other OAC [Artifacts](../rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md) are indexed by RERA.
+Ramate Eras (RERA) are the periods over which a governing body makes decisions. All other Ramate [Artifacts](../rglo/rera-000-000-000-dulan/rglo-000-000-000-artifact/README.md) are indexed by RERA.
 
 The current era is [RERA-0: Dulan](./rera-000-000-000-dulan/README.md).
 

--- a/rglo/README.md
+++ b/rglo/README.md
@@ -1,5 +1,5 @@
 # RGLO
-RGLOs are glosses or glossary entries for important terms in Ramate.
+Ramate Glosses (RGLO) are defined terms for Ramate.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RGLO: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rgov/README.md
+++ b/rgov/README.md
@@ -1,5 +1,5 @@
 # RGOV
-RGOVs are governance documents for Ramate.
+Ramate Governance (RGOV) are constitutions of, procedures for, and interpretations of Ramate governance.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RGOV: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rguide/README.md
+++ b/rguide/README.md
@@ -1,5 +1,5 @@
 # RGUIDE
-OAC Guides (RGUIDE) provide useful guides and summaries of OAC.
+Ramate Guides (RGUIDE) are guides or summaries of Ramate.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RGUIDE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rleg/README.md
+++ b/rleg/README.md
@@ -1,5 +1,5 @@
 # RLEG
-Description of RLEG.
+Ramate Legal Documents (RLEG) are published legal documents covering Ramate operations in any jurisdiction.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RLEG: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rlog/README.md
+++ b/rlog/README.md
@@ -1,4 +1,5 @@
 # RLOG
+Ramate Logs (RLOG) are periodically submitted logs describing various developments within the Ramate organization.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RLOG: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rpre/README.md
+++ b/rpre/README.md
@@ -1,4 +1,5 @@
 # RPRE
+Ramate Presentations (RPRE) are presentations about Ramate.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RPRE: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rproc/README.md
+++ b/rproc/README.md
@@ -1,4 +1,5 @@
 # RPROC
+Ramate Proclamations (RPROC) are statements of purpose for Ramate.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RPROC: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rroad/README.md
+++ b/rroad/README.md
@@ -1,5 +1,5 @@
 # RROAD
-RROADs are roadmaps for Ramate.
+Ramate Roadmaps (RROAD) are roadmaps describing the intents and objectives of Ramate as an organization.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RROAD: RERA-0: DULAN](rera-000-000-000-dulan/README.md)

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -1,4 +1,5 @@
 # RSPEC
+Ramate Specifications (RSPEC) describe specifications and are typically written in response to RDE. Generally, contributors should use RSPEC to justify non-trivial changes to this repository.
 
 <!--START OAC INDEX: DO NOT REMOVE THIS LINE -->
 ## [RSPEC: RERA-0: DULAN](rera-000-000-000-dulan/README.md)


### PR DESCRIPTION
# Summary
The descriptions were out of sync. This was missed in #30 and has been raised as a potential task for a pre-commit hook fix under https://github.com/ramate-io/oac/issues/31.